### PR TITLE
Fix the scope of cfg attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os="linux")]
+#![cfg(target_os="linux")]
 
 extern crate libc;
 use libc::{c_void, c_int, c_char, pid_t, ssize_t};


### PR DESCRIPTION
`#[cfg(target_os="linux")]` only works on the next line (`extern crate libc;`). 
You have to use `#![cfg(target_os="linux")]` instead, or cargo will compile this module regardless of the platform.

```bash
(Error on macOS)
   Compiling capabilities v0.3.0
error[E0432]: unresolved import `libc`
 --> ~/.cargo/registry/src/.../capabilities-0.3.0/src/lib.rs:4:5
  |
4 | use libc::{c_void, c_int, c_char, pid_t, ssize_t};
  |     ^^^^ Maybe a missing `extern crate libc;`?
```